### PR TITLE
Hide suggested videos on YouTube front page

### DIFF
--- a/userContent.css
+++ b/userContent.css
@@ -1,8 +1,15 @@
 @-moz-document domain(youtube.com) {
-    #related { display: none; }
+  #related,
+  .ytd-browse {
+    display: none !important;
+  }
 }
 
 @-moz-document domain(twitter.com) {
-    #timeline.content-main { display: none; }
-    .wtf-module { display: none !important; }
+  #timeline.content-main {
+    display: none;
+  }
+  .wtf-module {
+    display: none !important;
+  }
 }


### PR DESCRIPTION
Added `display: none` to suggested video grid on YouTube front page to get a cleaner experience that lets me search the site without losing focus.